### PR TITLE
Update metadataBase URL and image path

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -9,11 +9,11 @@ import Header from "@repo/ui/Header";
 const inter = Inter({subsets: ["latin"]});
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://hampterworks.github.io/schedule/'),
+  metadataBase: new URL('https://hampterworks.github.io/'),
   title: "Hampter Schedule",
   description: "Generate streaming schedules with time zone and discord support",
   openGraph: {
-    images: '/hampter.png'
+    images: '/schedule/hampter.png'
   },
   keywords:[
     'schedule',


### PR DESCRIPTION
The metadataBase URL has been updated to 'https://hampterworks.github.io/' from 'https://hampterworks.github.io/schedule/'. Additionally, the path to the open graph image has been updated to '/schedule/hampter.png', reflecting the change in directory structure. These changes ensure proper access to the base URL and image.