### PR TITLE
Add sitemap configuration to web app

### DIFF
--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next'
+
+const sitemap =(): MetadataRoute.Sitemap => {
+  return [
+    {
+      url: 'https://hampterworks.github.io/schedule/',
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: 'https://hampterworks.github.io/schedule/design',
+      lastModified: new Date(),
+      changeFrequency: 'yearly',
+      priority: 0.1,
+    }
+  ]
+}
+
+export default sitemap


### PR DESCRIPTION
Introduced a new file sitemap.ts that includes the configuration for a sitemap. The sitemap contains two URLs, 'https://hampterworks.github.io/schedule/' and 'https://hampterworks.github.io/schedule/design', with specified change frequency and priority settings for each.