### PR TITLE
Update clipboard copy to handle missing descriptions

### DIFF
--- a/packages/ui/src/ResultSection.tsx
+++ b/packages/ui/src/ResultSection.tsx
@@ -144,7 +144,7 @@ const ResultSection: React.FC<ResultSectionProps> = ({templates, timezones}) => 
             <Button
               label='Copy'
               onClick={() => {
-                navigator.clipboard.writeText(`${template.date}\n${template.description}\n${template.timezones?.join('\n')}`)
+                navigator.clipboard.writeText(`${template.date}\n${template.description ?? 'No description'}\n${template.timezones?.join('\n') ?? ''}`)
                   .then(() => setCopyNotice("Text copied successful!"))
                   .catch(error => setCopyNotice("Failed to copy text!"))
               }}


### PR DESCRIPTION
Modified the clipboard copy function to provide a default message when the template description is missing. This ensures that the text copied is always meaningful and avoids possible errors.