### PR TITLE
Add dark mode background styling to global CSS

### DIFF
--- a/apps/web/app/design/page.module.css
+++ b/apps/web/app/design/page.module.css
@@ -17,9 +17,3 @@
         display: block;
     }
 }
-
-@media (prefers-color-scheme: dark) {
-    .main {
-        background: #020202;
-    }
-}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -103,3 +103,9 @@ body {
   height: 100%;
   width: 100%;
 }
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #020202;
+  }
+}

--- a/apps/web/app/page.module.css
+++ b/apps/web/app/page.module.css
@@ -12,8 +12,4 @@
   padding: 16px;
 }
 
-@media (prefers-color-scheme: dark) {
-  .main {
-    background: #020202;
-  }
-}
+


### PR DESCRIPTION
Move the dark mode background styles from specific modules to the global stylesheet. This centralizes the styling rule for better maintainability and consistency across the application.