### PR TITLE
Set fixed width for DesignDisplay component

### DIFF
--- a/packages/ui/src/DesignDisplay.tsx
+++ b/packages/ui/src/DesignDisplay.tsx
@@ -190,6 +190,7 @@ const DayName = styled.div.attrs<{
     align-items: center;
     justify-content: space-between;
     background: ${props => props.$backgroundColor};
+    width: 12ch;
 
     span:first-of-type {
         font-size: ${props => `${props.$dayNameTextSize}px`};


### PR DESCRIPTION
Added a fixed width of 12ch to the DesignDisplay component to ensure consistent layout across different usages. This change improves alignment and visual presentation in various contexts where the component is rendered.