### PR TITLE
Handle null time selection in DateTimeSection.

### DIFF
--- a/packages/ui/src/DateTimeSection.tsx
+++ b/packages/ui/src/DateTimeSection.tsx
@@ -81,7 +81,8 @@ const DateTimeSection: React.FC<DateTimeControllerProps> = ({templates, setTempl
               type='time'
               value={template.time ?? ''}
               onInput={selectedTime => {
-                setTemplate(index, {...template, time: (selectedTime as string)})
+                if (selectedTime)
+                  setTemplate(index, {...template, time: (selectedTime as string)})
               }}
               disabled={template.wholeDay ?? false}
             />


### PR DESCRIPTION
Previously, the code did not account for potential null values when setting the time in the template, which could lead to errors. The update ensures that the `setTemplate` function is only called when a valid `selectedTime` is provided.